### PR TITLE
Add prototype for national-stocktake scenario register

### DIFF
--- a/definitions/scenario/national-stocktake-studies.yaml
+++ b/definitions/scenario/national-stocktake-studies.yaml
@@ -1,0 +1,14 @@
+- NRF-*:
+    model: GCAM-USA-CGS  # version number to be added
+    meta-indicators:
+      Project: NRF
+      Scientific Reference (Citation): Zhao et al. (2024)
+      Scientific Reference (DOI): 10.1038/s44168-024-00145-x
+      Work Package: 5.1 (National Stocktake)
+- GIR-*:
+    model: [ AIMHub-Korea, GCAM-KAIST, MESSAGEix-KOR ] # version numbers to be added
+    meta-indicators:
+      Project: GIR
+      Scientific Reference (Citation): Cho et al. (2025)
+      Scientific Reference (DOI): 10.1016/j.egycc.2025.100193
+      Work Package: 5.1 (National Stocktake)

--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -1,6 +1,7 @@
 dimensions:
   - variable
   - region
+  - scenario
 repositories:
   common-definitions:
     url: https://github.com/IAMconsortium/common-definitions.git/


### PR DESCRIPTION
This PR activates validation for scenarios that are submitted as part of the national-stocktake (WP5.1) and adds attributes so that submitted scenarios are automatically assigned the relevant meta-indicators for filtering via the Scenario Explorer user interface.