### PR TITLE
Add 'Regional Organizations' to nomenclature hierarchy

### DIFF
--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -16,6 +16,7 @@ definitions:
         - hierarchy: R9
         - hierarchy: R10
         - hierarchy: G20 Members
+        - hierarchy: Regional Organizations
 #         - hierarchy: .. add model hierarchy here
 #mappings:
 #  repository:


### PR DESCRIPTION
This is to preempt mapping-issues after merging https://github.com/IAMconsortium/common-definitions/pull/346